### PR TITLE
Export property_value_maximum_size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.netflix.hystrix</groupId>
             <artifactId>hystrix-core</artifactId>
-            <version>1.5.6</version>
+            <version>1.5.9</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/soundcloud/prometheus/hystrix/HystrixPrometheusMetricsPublisherThreadPool.java
+++ b/src/main/java/com/soundcloud/prometheus/hystrix/HystrixPrometheusMetricsPublisherThreadPool.java
@@ -110,6 +110,12 @@ public class HystrixPrometheusMetricsPublisherThreadPool implements HystrixMetri
                     return properties.coreSize().get();
                 }
             });
+            addGauge("property_value_maximum_size", doc, new Callable<Number>() {
+                @Override
+                public Number call() {
+                    return properties.maximumSize().get();
+                }
+            });
             addGauge("property_value_keep_alive_time_in_minutes", doc, new Callable<Number>() {
                 @Override
                 public Number call() {


### PR DESCRIPTION
Changes needed to export the metric about maximum threadpool size. I bumped the Hystrix version to the one that added this feature.

Please, let me know what you think and if you'll be able to make a release.

Thank you very much!